### PR TITLE
fix: `kstrsub` function array wrong memory access (stack smashing)

### DIFF
--- a/src/kstring.c
+++ b/src/kstring.c
@@ -99,7 +99,7 @@ void kstrsub(char *dest, const char *src, u64 start, u64 len) {
   }
   if (len > 0) {
     for (u64 i = start, j = 0; j < len && src[i]; ++i, ++j) dest[j] = src[i];
-    dest[start + len] = 0;
+    dest[len] = 0;
   }
   else {
     u64 j = 0;


### PR DESCRIPTION
To solve an error in the `kstrsub` function of the `kstring` module, this patch is being submitted.
The memory access done in `dest[start + len] = 0;` is not correct, as the wanted substring is `len` long; thus, it is only needed to terminate the selected substring in `dest` after the amount of characters specified through the `len` argument.

## Description

**Please, include a summary of the changes and which issue(s) is/are fixed. Also include relevant motivation and context. Lastly, list any dependencies that are required for this change.**

While predefining unit tests for `kstring` module (#23), it spit out the error: `*** stack smashing detected ***: terminated`. This message typically indicates a buffer overflow. This happens when you write more data to a block of memory (like an array) than it can hold; basically, when a program uses more stack memory than it's allowed to.

The issue is in the line containing: `dest[start + len] = 0;`. Here, it's trying to set the character at the index `start + len` to null, i.e. mark the string as terminated at that specific point. However, the specific substring wanted to obtain is exactly `len` chars long, so there is no point in terminating the `dest` array `start` more chars than it needs: appart from being innecessary, if the `dest` array is less than `start + len` long (perfectly feasible as the wanted substring to hold there is only `len` chars long), it will try to write past the end of `dest`, causing a buffer overflow.

**Issues:**
- N/A
---
**Motivation and context:**
- Detected wrong behavior while working on #23
---
**Dependencies:**
- N/A

### Development and testing equipment

**Development PC specs:**
- **CPU:** R7 3800X 4.0GHz @ 1.05V
- **RAM:** 96GB DDR4 2400MT/s
- **GPU:** RTX 2060 SUPER
- **OS:** GNU/Linux (Gentoo)
- **Glibc version:** 2.37
- **GCC version:** 13.2.1
- **Vulkan version:** 1.3.261
---
**Please, describe the tests that you ran to verify your changes. Provide instructions so it can be reproducible. Also list any relevant details for your test configuration.**

- Preliminary version of unit tests implemented in #23; testing the function when obtaining a substring from the start, mid, and end of a predefined string.

## Type of change

- [ ] Bug fix (non-breaking change which fixes one or multiple issues).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [ ] I've read and comply with the [contributing guidelines](https://github.com/iWas-Coder/wge/blob/master/CONTRIBUTING.org).
- [ ] I've tested my changes for new features and regressions on all supported operating systems.
- [ ] I've made corresponding changes to the documentation.
- [ ] I've checked my changes for any broken behaviour and/or any unjustified performance hits.
- [ ] My changes generate no new warnings.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
