### PR TITLE
fix: add braces to possibly empty body in else statements

### DIFF
--- a/src/material_system.c
+++ b/src/material_system.c
@@ -214,9 +214,11 @@ material *material_system_get_from_cfg(material_config cfg) {
            cfg.name,
            ref.ref_count);
   }
-  else KTRACE("Material '%s' already exists. `ref_count` -> %i",
-              cfg.name,
-              ref.ref_count);
+  else {
+    KTRACE("Material '%s' already exists. `ref_count` -> %i",
+           cfg.name,
+           ref.ref_count);
+  }
   // Update entry
   hash_table_set(&state_ptr->registered_material_table, cfg.name, &ref);
   return &state_ptr->registered_materials[ref.handle];
@@ -245,10 +247,12 @@ void material_system_release(const char *name) {
     ref.auto_release = false;
     KTRACE("Material '%s' released (`ref_count` -> 0 && `auto_release` -> true)", name);
   }
-  else KTRACE("Material '%s' released (`ref_count` -> %i && `auto_release` -> %s)",
-              name,
-              ref.ref_count,
-              ref.auto_release ? "true" : "false");
+  else {
+    KTRACE("Material '%s' released (`ref_count` -> %i && `auto_release` -> %s)",
+           name,
+           ref.ref_count,
+           ref.auto_release ? "true" : "false");
+  }
   // Update entry
   hash_table_set(&state_ptr->registered_material_table, name, &ref);
 }

--- a/src/texture_system.c
+++ b/src/texture_system.c
@@ -228,9 +228,11 @@ texture *texture_system_get(const char *name, b8 auto_release) {
            name,
            ref.ref_count);
   }
-  else KTRACE("Texture '%s' already exists. `ref_count` -> %i",
-              name,
-              ref.ref_count);
+  else {
+    KTRACE("Texture '%s' already exists. `ref_count` -> %i",
+           name,
+           ref.ref_count);
+  }
   // Update entry
   hash_table_set(&state_ptr->registered_texture_table, name, &ref);
   return &state_ptr->registered_textures[ref.handle];
@@ -269,10 +271,12 @@ void texture_system_release(const char *name) {
     ref.auto_release = false;
     KTRACE("Texture '%s' released (`ref_count` -> 0 && `auto_release` -> true)", name_cp);
   }
-  else KTRACE("Texture '%s' released (`ref_count` -> %i && `auto_release` -> %s)",
-              name_cp,
-              ref.ref_count,
-              ref.auto_release ? "true" : "false");
+  else {
+    KTRACE("Texture '%s' released (`ref_count` -> %i && `auto_release` -> %s)",
+           name_cp,
+           ref.ref_count,
+           ref.auto_release ? "true" : "false");
+  }
   // Update entry
   hash_table_set(&state_ptr->registered_texture_table, name_cp, &ref);
 }


### PR DESCRIPTION
## Description

**Please, include a summary of the changes and which issue(s) is/are fixed. Also include relevant motivation and context. Lastly, list any dependencies that are required for this change.**

**Issues:**
- N/A
---
**Motivation and context:**
- While working on the Makefile, and testing the release build mode, I notices these places where, while building in the release mode, the else block would end up being empty without braces. Fixed it adding braces to those bodies.
---
**Dependencies:**
- N/A
---
**Tests:**
- N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes one or multiple issues).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist:
- [x] I've read and comply with the [contributing guidelines](https://github.com/iWas-Coder/wge/blob/master/CONTRIBUTING.org).
- [ ] I've tested my changes for new features and regressions on all supported operating systems.
- [ ] I've made corresponding changes to the documentation.
- [x] I've checked my changes for any broken behaviour and/or any unjustified performance hits.
- [x] My changes generate no new warnings.
- [ ] I've added tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
